### PR TITLE
fix: visitArguments should travel sub fields

### DIFF
--- a/src/astBuilder.ts
+++ b/src/astBuilder.ts
@@ -81,13 +81,13 @@ import {
   IndexSignatureNode,
   TemplateLiteralExpression,
 } from "../as";
-import { AbstractVisitor } from "./visitor";
+import { BaseVisitor } from "./base";
 
 // declare function i64_to_string(i: I64): string;
 // import { i64_to_string } from "../../../src/glue/i64"
 
 /** An AST builder. */
-export class ASTBuilder extends AbstractVisitor<Node> {
+export class ASTBuilder extends BaseVisitor {
   _visit(node: Node): void {
     this.visitNode(node);
   }
@@ -548,7 +548,7 @@ export class ASTBuilder extends AbstractVisitor<Node> {
     this.visitArguments(node.typeArguments, node.args);
   }
 
-  private visitArguments(
+  visitArguments(
     typeArguments: TypeNode[] | null,
     args: Expression[]
   ): void {

--- a/src/base.ts
+++ b/src/base.ts
@@ -398,11 +398,16 @@ export class BaseVisitor extends AbstractVisitor<Node> {
     this.visitArguments(node.typeArguments, node.args);
   }
 
-  visitArguments(
-    typeArguments: TypeNode[] | null,
+  visitArguments(typeArguments: TypeNode[] | null, args: Expression[]): void {
+    let typeArgs = typeArguments ? typeArguments : [];
+    for(const typeArg of typeArgs) {
+      this.visitTypeNode(typeArg)
+    }
 
-    args: Expression[]
-  ): void {}
+    for(const arg of args) {
+      this.visit(arg)
+    }
+  }
 
   visitClassExpression(node: ClassExpression): void {
     this.visit(node.declaration);

--- a/src/base.ts
+++ b/src/base.ts
@@ -399,14 +399,8 @@ export class BaseVisitor extends AbstractVisitor<Node> {
   }
 
   visitArguments(typeArguments: TypeNode[] | null, args: Expression[]): void {
-    let typeArgs = typeArguments ? typeArguments : [];
-    for(const typeArg of typeArgs) {
-      this.visitTypeNode(typeArg)
-    }
-
-    for(const arg of args) {
-      this.visit(arg)
-    }
+    this.visit(typeArguments);
+    this.visit(args);
   }
 
   visitClassExpression(node: ClassExpression): void {


### PR DESCRIPTION
I meet some problems when do some transforms fro function call. And then I find the visitArguments have not done anything.

So I fix the base.ts, but baseTransform.ts cannot be fixed easily without api break change