### PR TITLE
Fix parsing of import statement

### DIFF
--- a/__tests__/tests.spec.js
+++ b/__tests__/tests.spec.js
@@ -162,6 +162,10 @@ describe("Parser", () => {
       _class.members.push(methodAST);
       expect(_class.members[1].name.text).to.equal("getF");
     })
+
+    it("should be able to import something", () => {
+      SimpleParser.parseTopLevelStatement("import { x } from 'y'");
+    });
   })
 
 });

--- a/src/simpleParser.ts
+++ b/src/simpleParser.ts
@@ -39,7 +39,10 @@ export class SimpleParser {
     s: string,
     namespace?: NamespaceDeclaration | null
   ): Statement {
-    const res = this.parser.parseTopLevelStatement(this.getTokenizer(s), namespace);
+    const t = this.getTokenizer(s);
+    const p = this.parser;
+    p.currentSource = t.source;
+    const res = p.parseTopLevelStatement(t, namespace);
     if (res == null) {
       throw new Error("Failed to parse the top level statement: '" + s + "'");
     }


### PR DESCRIPTION
Parsing a top-level `import` statement should work, but fails with the following:

```
AssertionError: assertion failed
      at Y.assert (file:///Users/matt/Code/visitor-as/node_modules/assemblyscript/dist/assemblyscript.js:9:3029)
      at Kn.parseImport (file:///Users/matt/Code/visitor-as/node_modules/assemblyscript/dist/assemblyscript.js:17:124365)
      at Kn.parseTopLevelStatement (file:///Users/matt/Code/visitor-as/node_modules/assemblyscript/dist/assemblyscript.js:17:102113)
      at SimpleParser.parseTopLevelStatement (file:///Users/matt/Code/visitor-as/dist/simpleParser.js:24:33)
      at Context.<anonymous> (file:///Users/matt/Code/visitor-as/__tests__/tests.spec.js:166:20)
      at process.processImmediate (node:internal/timers:478:21)
```

This PR adds a test for that, and fixes it by setting the parser's `currentSource` property.

I'm not certain if the same fix is required for the other parsing methods or not.  I only found the problem while trying to parse an import statement.  LMK if you want me to make the same fix to the other parsing methods.   Thanks.